### PR TITLE
  [FEATURE] Adds new syntax for Verto DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ If you need a more specific configuration or want to reflect your development pr
 
 ```ruby
 # Vertofile
+
+verto_version "0.2.1"
+
 config {
   pre_release.initial_number = 0
   project.path = "my/repo/path"

--- a/exe/verto
+++ b/exe/verto
@@ -8,7 +8,8 @@ begin
   Verto::DSL.load_file(vertofile_path) if File.exists?(vertofile_path)
 
   Verto::MainCommand.start(ARGV)
-rescue Verto::ExitError
+rescue Verto::ExitError => ex
+  Verto.stderr.puts ex.message
   Verto.stderr.puts 'Exiting Verto...'
   exit 1
 end

--- a/lib/verto.rb
+++ b/lib/verto.rb
@@ -5,6 +5,7 @@ require "dry-auto_inject"
 require "pathname"
 
 require "verto/version"
+require "verto/utils/command_options"
 
 module Verto
   extend Dry::Configurable
@@ -23,7 +24,7 @@ module Verto
   end
 
   setting :hooks, []
-  setting :command_options, Class.new(Hash) { alias_method :add, :merge! }.new
+  setting :command_options, CommandOptions.new
 
   ExitError = Class.new(Thor::Error)
   CommandError = Class.new(ExitError)

--- a/lib/verto/commands/base_command.rb
+++ b/lib/verto/commands/base_command.rb
@@ -11,7 +11,7 @@ module Verto
     end
 
     def options
-      super.merge Verto.config.command_options
+      Verto.config.command_options.merge(super)
     end
 
     def call_hooks(moments = [], with_attributes: {})

--- a/lib/verto/utils/command_options.rb
+++ b/lib/verto/utils/command_options.rb
@@ -1,0 +1,9 @@
+module Verto
+  class CommandOptions < Thor::CoreExt::HashWithIndifferentAccess
+    alias_method :add, :merge!
+
+    def except(*keys)
+      self.reject { |key, v| keys.include?(key) }
+    end
+  end
+end

--- a/lib/verto/utils/tag_filter.rb
+++ b/lib/verto/utils/tag_filter.rb
@@ -5,6 +5,7 @@ module TagFilter
   FILTERS = {
     release_only: REALEASE_ONLY,
     pre_release_only: PRE_REALEASE_ONLY,
+    all: nil
   }
 
   def self.for(tag_key)

--- a/spec/lib/commands/main_command_spec.rb
+++ b/spec/lib/commands/main_command_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Verto::MainCommand do
       subject(:up) { described_class.start(['tag','up'] + options ) }
 
       let(:options) { [] }
+      let(:vertofile) { nil }
+
+      before do
+        Verto::DSL::Interpreter.new.evaluate(vertofile) if vertofile
+      end
 
       context 'when the repository doesnt have a previous tag' do
          before do


### PR DESCRIPTION
  **NEW SYNTAX:**
  **verto_version**

     Used to set a specific verto_version, when the
     current version is lower than the expected version
     verto exits in error.

  **latest_version**

    Returns the current latest version
    If the version doesn't exists it returns 0.0.0

  **latest_release_version**

    Returns the latest release version
    If the version doesn't exists it returns 0.0.0

  **latest_pre_release_version**

    Returns the latest pre_release version.
    If the version doesn't exists it returns 0.0.0

  **NEW OPTIONS:**

  **sh, sh!:**

     Adds optional stdout_output:, to disable stdout output(false), enable (true) or
     use the config option (:config, default)

  **git:**

     Adds optional stdout_output:, to disable stdout output(false, default), enable (true) or
     use the config option (:config)