### PR TITLE
  [FIX] Tag up with multiple options

### DIFF
--- a/lib/verto/commands/tag_command.rb
+++ b/lib/verto/commands/tag_command.rb
@@ -35,14 +35,15 @@ module Verto
     include Verto.import['tag_repository']
 
     def up_version(version, options)
-      version_up_options = options.select { |key,value| value == true }.keys.map(&:to_sym) & [:major, :minor, :patch]
+      up_options = options.select { |key,value| value == true }.keys.map(&:to_sym) & [:major, :minor, :patch]
+      up_option = up_options.sort.first
 
-      new_version = version_up_options.reduce(version) { |version, up_option| version.up(up_option) }
+      new_version = version.up(up_option)
 
       if options[:pre_release]
         identifier = pre_release_configured? ? options[:pre_release] : version.pre_release.name
         new_version = new_version.with_pre_release(identifier)
-        new_version = new_version.up(:pre_release) if new_version.pre_release.name == version.pre_release.name
+        new_version = new_version.up(:pre_release) if new_version.pre_release.name == version.pre_release.name && new_version == version
       end
 
       new_version

--- a/spec/lib/commands/main_command_spec.rb
+++ b/spec/lib/commands/main_command_spec.rb
@@ -197,6 +197,18 @@ RSpec.describe Verto::MainCommand do
                 expect(result).to include('tag: 0.0.2)')
               end
             end
+
+            context 'and with a --pre_release' do
+              let(:options) { ['--patch', '--pre_release=rc'] }
+              let(:last_tag) { '1.9.19-rc.1' }
+
+              it 'upgrades only the patch number' do
+                up
+
+                result = repo.run('git log --decorate HEAD')
+                expect(result).to include('tag: 1.9.20-rc.1)')
+              end
+            end
           end
         end
 
@@ -222,6 +234,41 @@ RSpec.describe Verto::MainCommand do
             end
           end
 
+          context 'and with a minor' do
+            let(:options) { ['--minor', '--patch'] }
+            let(:last_tag) { '1.9.19' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 1.10.0)')
+            end
+          end
+
+          context 'and with a --patch' do
+            let(:options) { ['--minor', '--patch'] }
+            let(:last_tag) { '1.9.19-rc.1' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 1.10.0-rc.1)')
+            end
+          end
+
+          context 'and with a --pre_release' do
+            let(:options) { ['--minor', '--pre_release=rc'] }
+            let(:last_tag) { '1.9.19-rc.1' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 1.10.0-rc.1)')
+            end
+          end
         end
 
         context 'with --major option' do
@@ -245,6 +292,43 @@ RSpec.describe Verto::MainCommand do
               expect(result).to include('tag: 2.0.0-rc.1')
             end
           end
+
+          context 'and with a --minor' do
+            let(:options) { ['--major', '--minor'] }
+            let(:last_tag) { '1.9.19-rc.1' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 2.0.0-rc.1)')
+            end
+          end
+
+          context 'and with a --patch' do
+            let(:options) { ['--major', '--patch'] }
+            let(:last_tag) { '1.9.19-rc.1' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 2.0.0-rc.1)')
+            end
+          end
+
+          context 'and with a --pre_release' do
+            let(:options) { ['--major', '--pre_release=rc'] }
+            let(:last_tag) { '1.9.19-rc.1' }
+
+            it 'upgrades only the minor number' do
+              up
+
+              result = repo.run('git log --decorate HEAD')
+              expect(result).to include('tag: 2.0.0-rc.1)')
+            end
+          end
+
         end
 
         context 'with --pre-release option' do


### PR DESCRIPTION
  Fix a bug when running verto with multiple options

  Eg: With a tag `1.0.0-rc.1` is expected that `verto tag up --patch --pre_release=rc`
  creates a `1.0.1-rc.1` tag, but the created tag before this fix is `1.0.1-rc.2`