### PR TITLE
  [Feature] Adds Release Option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       dry-configurable (~> 0.8)
       dry-container (~> 0.7)
       thor (~> 1.0.1)
-      vseries (~> 0.1)
+      vseries (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -46,7 +46,7 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
     thor (1.0.1)
-    vseries (0.1.1)
+    vseries (0.2.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -67,10 +67,21 @@ You can run verto right out of the box without any configuration:
   verto tag up --patch # Creates a new tag increasing the patch number
   verto tag up --minor # Creates a new tag increasing the minor number
   verto tag up --major # Creates a new tag increasing the major number
-  
+
   # You can also work with pre release identifiers
   verto tag up --major --pre_release=rc # Creates a new tag increasing the major number and adding the rc identifier
   verto tag up --pre_release=rc # Creates a new tag increasing the pre_release number, eg: rc.1 to rc.2
+
+  # Or ensure that a release tag will be created, eg: with a last tag 1.1.1-rc.1
+
+  verto tag up --release # Creates a 1.1.1 tag
+
+  # You can filter the tags you want to consider for increasing
+
+  verto tag up --patch --filter=release_only # For Realease Tags Only
+  verto tag up --patch --filter=pre_release_only # For Pre Realease Tags Only
+  verto tag up --patch --filter='\d+\.\d+\.\d+-alpha.*' # Custom Regexp!
+
 ```
 
 ### Verto DSL

--- a/lib/verto/commands/base_command.rb
+++ b/lib/verto/commands/base_command.rb
@@ -14,6 +14,10 @@ module Verto
       Verto.config.command_options.merge!(super)
     end
 
+    def stderr
+      Verto.stderr
+    end
+
     def call_hooks(moments = [], with_attributes: {})
       moments_to_call = ([] << moments).flatten
 

--- a/verto.gemspec
+++ b/verto.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency             "dry-configurable", "~> 0.8"
   spec.add_dependency             "dry-container", "~> 0.7"
   spec.add_dependency             "dry-auto_inject", "~> 0.7"
-  spec.add_dependency             "vseries", "~> 0.1"
+  spec.add_dependency             "vseries", "~> 0.2"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
  Adds new option --release for tag up command.

  It ensures that the new tag is a release version.

  Eg:
    1. With a latest tag 1.2.1-rc.1 running verto tag up --release will
       create a 1.2.1 tag
    2. With a latest tag 1.2.1-rc.1 running verto tag up --patch --release will
       create 1.2.2 tag
    3. With a latest tag 1.2.1 running verto tag up --patch --release will
       create 1.2.1 tag

  Bonus Feature: Outputs the created tag in the stderr

      eg: Creating Tag 1.0.20...
            Tag 1.0.20 Created!

