### PR TITLE
  [FEATURE Built In Git Hooks]

### DIFF
--- a/Vertofile
+++ b/Vertofile
@@ -1,4 +1,4 @@
-verto_version '0.5.0'
+verto_version '0.6.1'
 
 config {
  version.prefix = 'v' # Adds a version_prefix
@@ -49,7 +49,6 @@ context(branch('master')) {
     exit
     git!('push --tags')
     git!('push origin master')
-    sh!('rake release')
   }
 }
 

--- a/lib/verto.rb
+++ b/lib/verto.rb
@@ -26,6 +26,14 @@ module Verto
 
   setting :version do
     setting :prefix, ''
+    setting :validations do
+      setting :new_version_must_be_bigger, true
+    end
+  end
+
+  setting :git do
+    setting :pull_before_tag_creation, false
+    setting :push_after_tag_creation, false
   end
 
   setting :hooks, []
@@ -88,6 +96,7 @@ require "verto/dsl/syntax"
 require "verto/dsl/interpreter"
 require "verto/dsl/hook"
 require "verto/dsl/file"
+require "verto/dsl/built_in_hooks"
 require "verto/commands/base_command"
 require "verto/commands/tag_command"
 require "verto/commands/main_command"

--- a/lib/verto/dsl/built_in_hooks.rb
+++ b/lib/verto/dsl/built_in_hooks.rb
@@ -1,0 +1,22 @@
+module Verto
+  module DSL
+    module BuiltInHooks
+      GitPullCurrentBranch = DSL::Hook.new(moment: :before) do
+        git!("pull origin #{current_branch}")
+      end
+
+      GitPushTags = DSL::Hook.new(moment: :after) do
+        git!("push --tags")
+      end
+
+      GitPushCurrentBranchCommits = DSL::Hook.new(moment: :after) do
+        git!("push origin #{current_branch}")
+      end
+
+      GitPushCurrentBranch = DSL::Hook.new(moment: :after) do
+        GitPushTags.call
+        GitPushCurrentBranchCommits.call
+      end
+    end
+  end
+end

--- a/lib/verto/dsl/syntax.rb
+++ b/lib/verto/dsl/syntax.rb
@@ -55,15 +55,11 @@ module Verto
       end
 
       def sh!(command, output: :from_config)
-        raise Verto::ExitError unless sh(command, output: output).success?
+        raise Verto::ExitError, command unless sh(command, output: output).success?
       end
 
       def command_options
         Verto.config.command_options
-      end
-
-      def on(moment, &block)
-        Verto.config.hooks << Hook.new(moment: moment, &block)
       end
 
       def before(&block)
@@ -74,12 +70,34 @@ module Verto
         Verto.config.hooks << Hook.new(moment: :after, &block)
       end
 
+      def on(moment, &block)
+        deprecate('on', use: 'before_tag_creation')
+
+        Verto.config.hooks << Hook.new(moment: moment, &block)
+      end
+
       def before_command(command_name, &block)
+        deprecate('before_command', use: 'before_command_tag_up')
+
         Verto.config.hooks << Hook.new(moment: "before_#{command_name}", &block)
       end
 
       def after_command(command_name, &block)
+        deprecate('after_command', use: 'after_command_tag_up')
+
         Verto.config.hooks << Hook.new(moment: "after_#{command_name}", &block)
+      end
+
+      def before_command_tag_up(&block)
+        Verto.config.hooks << Hook.new(moment: 'before_tag_up', &block)
+      end
+
+      def after_command_tag_up(&block)
+        Verto.config.hooks << Hook.new(moment: 'after_tag_up', &block)
+      end
+
+      def before_tag_creation(&block)
+        Verto.config.hooks << Hook.new(moment: 'before_tag_creation', &block)
       end
 
       def file(filepath)
@@ -134,6 +152,10 @@ module Verto
         return SemanticVersion.new('0.0.0') unless tag_version
 
         SemanticVersion.new(tag_version)
+      end
+
+      def deprecate(current, use:)
+        warn "[DEPRECATED] `#{current}` is deprecated and wil be removed in a future release, use `#{use}` instead"
       end
     end
   end

--- a/lib/verto/utils/templates/Vertofile
+++ b/lib/verto/utils/templates/Vertofile
@@ -4,16 +4,17 @@ config {
  # version.prefix = 'v' # Adds a version_prefix
  # pre_release.initial_number = 0 # Configures pre_release initial number, defaults to 1
  # project.path = "#{project_path}" # Configures a custom project path
+ # git.pull_before_tag_creation = true # Pull Changes before tag creation
+ # git.push_after_tag_creation = true # Push changes after tag creation
 }
 
 context(branch('master')) {
-  before_command('tag_up') {
+  before_command_tag_up {
     git!('pull origin master')
     command_options.add(filter: 'release_only')
   }
 
-  on('before_tag_creation') {
-
+  before_tag_creation{
     version_changes = ""
     # Uncomment to get Merged PRs Titles as changes to add in CHANGELOG.
     # version_changes = sh(
@@ -39,7 +40,7 @@ context(branch('master')) {
     git('commit -m "Updates CHANGELOG"')
   }
 
-  after_command('tag_up') {
+  after_command_tag_up {
     git('push --tags')
     git('push origin master')
   }
@@ -47,18 +48,18 @@ context(branch('master')) {
 
 # Uncomment to get a specific pre_release proccess, like a staging or qa branch
 # context(branch('staging')) {
-#  before_command('tag_up') {
+#  before_command_tag_up {
 #    git!('pull origin staging')
 #    command_options.add(pre_release: 'rc')
 #  }
 #
-#  on('before_tag_creation') {
+#  before_tag_creation {
 #    file('package.json').replace(/"(\d+)\.(\d+)\.(\d+)(-?.*)"/, %Q{"#{new_version}"}) # Atualiza versão do package.json
 #    git('add package.json')
 #    git('commit --allow-empty -m "Staging Release"')
 #  }
 
-#  after_command('tag_up') {
+#  after_command_tag_up {
 #    git('push --tags')
 #    git('push origin staging')
 #  }

--- a/spec/verto/dsl/built_in_hooks_spec.rb
+++ b/spec/verto/dsl/built_in_hooks_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Verto::DSL::BuiltInHooks do
+  let(:interpreter) { Verto::DSL.interpreter }
+  let(:repo) { TestRepo.new }
+  let(:current_branch) { 'master' }
+
+  before do
+    Verto.config.project.path = Verto.root_path.join('tmp/test_repo/').to_s
+    repo.clear!
+    repo.init!
+  end
+
+  describe described_class::GitPullCurrentBranch do
+    subject(:call) { described_class.call }
+
+    it 'pull current branch changes' do
+      allow(interpreter).to receive(:git!)
+
+      call
+
+      expect(interpreter).to have_received(:git!).with("pull origin #{current_branch}").once
+    end
+  end
+
+  describe described_class::GitPushTags do
+    subject(:call) { described_class.call }
+
+    it 'pull current branch changes' do
+      allow(interpreter).to receive(:git!)
+
+      call
+
+      expect(interpreter).to have_received(:git!).with("push --tags").once
+    end
+  end
+
+  describe described_class::GitPushCurrentBranchCommits do
+    subject(:call) { described_class.call }
+
+    it 'pull current branch changes' do
+      allow(interpreter).to receive(:git!)
+
+      call
+
+      expect(interpreter).to have_received(:git!).with("push origin #{current_branch}").once
+    end
+  end
+
+  describe described_class::GitPushCurrentBranch do
+    subject(:call) { described_class.call }
+
+    it 'pull current branch changes' do
+      allow(interpreter).to receive(:git!)
+
+      call
+
+      expect(interpreter).to have_received(:git!).with("push --tags").once
+      expect(interpreter).to have_received(:git!).with("push origin #{current_branch}").once
+    end
+  end
+end

--- a/spec/verto/dsl/syntax_spec.rb
+++ b/spec/verto/dsl/syntax_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Verto::DSL::Syntax do
+end

--- a/verto.gemspec
+++ b/verto.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
 
-  # spec.metadata["homepage_uri"] = spec.homepage
-  # spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/catks/verto"
+  spec.metadata["changelog_uri"] = "https://github.com/catks/verto/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
  * [FEATURE] Adds config.git.pull_before_tag_creation(default: false) and
    config.git.push_after_tag_creation(default: false) creating a hook to pull changes
    before creating a tag or to push changes after creating a tag

  * [FEATURE] Adds config.version.validations.new_version_must_be_bigger (default: true)

  * [PATCH] Adds before_command_tag_up, before_tag_creation, after_command_tag_up

  * [PATCH] Deprecates 'before_command', 'after_command' and 'on' syntax