### PR TITLE
  [FEATURE] Custom Default Pre-Release Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ verto_version '0.8.0'
 
 config {
  # version.prefix = 'v' # Adds a version_prefix
+ # pre_release.default_identifier = 'alpha' } # Defaults to 'rc'
  git.pull_before_tag_creation = true # Pull Changes before tag creation
  git.push_after_tag_creation = true # Push changes after tag creation
 }

--- a/lib/verto.rb
+++ b/lib/verto.rb
@@ -13,6 +13,7 @@ module Verto
 
   setting :pre_release do
     setting :initial_number, 1
+    setting :default_identifier, 'rc'
   end
 
   setting :project do


### PR DESCRIPTION
  * [FEATURE] Adds pre_release.default_identifier config
  * [FIX] Fix tag up for --patch --pre-release when the latest version
    is a release version (before with a tag 1.0.0, running --patch
    --pre-release without specifing the identifier creates a 1.0.0-.1 tag