### PR TITLE
  [FEATURE] Adds update_changelog in DSL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       dry-auto_inject (~> 0.7)
       dry-configurable (~> 0.8)
       dry-container (~> 0.7)
+      mustache (~> 1.1.1)
       thor (~> 1.0.1)
       vseries (~> 0.2)
 
@@ -12,7 +13,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.1.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.3)
     docile (1.3.2)
     dry-auto_inject (0.7.0)
@@ -27,6 +28,7 @@ GEM
     dry-core (0.4.9)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
+    mustache (1.1.1)
     rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/Vertofile
+++ b/Vertofile
@@ -1,4 +1,4 @@
-verto_version '0.7.0'
+verto_version '0.9.0'
 
 config {
   version.prefix = 'v' # Adds a version_prefix
@@ -12,22 +12,7 @@ context(branch('master')) {
   }
 
   before_tag_creation {
-    version_changes = ""
-     bitbucket_changes = sh(
-      %q#git log --oneline --decorate  | grep -B 100 -m 1 "tag:" | grep "pull request" | awk '{print $1}' | xargs git show --format='%b' | grep -v Approved | grep -v "^$" | grep -E "^[[:space:]]*\[.*\]" | sed 's/^[[:space:]]*\(.*\)/ * \1/'#, output: false
-     ).output
-     version_changes = bitbucket_changes
-
-    puts "---------------------------"
-    version_changes = "## #{new_version} - #{Time.now.strftime('%d/%m/%Y')}\n#{version_changes}\n"
-    exit unless confirm("Create new Realease?\n" \
-      "---------------------------\n" \
-      "#{version_changes}" \
-      "---------------------------\n"
-    )
-
-    # CHANGELOG
-    file('CHANGELOG.md').prepend(version_changes)
+    update_changelog
     git!('add CHANGELOG.md')
 
     file('lib/verto/version.rb').replace(latest_version.to_s, new_version.to_s)
@@ -37,6 +22,8 @@ context(branch('master')) {
     git!('add README.md')
 
     file('lib/verto/utils/templates/Vertofile').replace(latest_version.to_s, new_version.to_s)
+    file('Vertofile').replace(latest_version.to_s, new_version.to_s)
+
     git!('add lib/verto/utils/templates/Vertofile')
 
     sh!('bundle install')

--- a/djin.yml
+++ b/djin.yml
@@ -1,0 +1,8 @@
+djin_version: '0.6.0'
+
+tasks:
+  release:
+    local:
+      run:
+        - verto tag up {{args}}
+        - bundle exec rake release

--- a/lib/verto/commands/base_command.rb
+++ b/lib/verto/commands/base_command.rb
@@ -24,7 +24,10 @@ module Verto
       moments_to_call.each do |moment|
         Verto.config.hooks
           .select { |hook| hook.moment == moment.to_sym }
-          .each { |hook| hook.call(with_attributes: with_attributes) }
+          .each do |hook|
+            Verto.current_moment = hook.moment
+            hook.call(with_attributes: with_attributes)
+          end
       end
     end
   end

--- a/lib/verto/dsl/update_changelog.rb
+++ b/lib/verto/dsl/update_changelog.rb
@@ -1,0 +1,56 @@
+module Verto
+  module DSL
+    class UpdateChangelog
+      include Verto.import[:cli_helpers, :stdout,
+                           executor: 'system_command_executor_without_output', changelog_format: 'changelog.format']
+
+      InvalidChangelogSource = Class.new(Verto::ExitError)
+
+      SOURCES = StrictHash.new(
+        {
+          merged_pull_requests_with_bracketed_labels: lambda do |executor|
+            executor.run(
+              %q#git log --oneline --decorate  | grep -B 100 -m 1 "tag:" | grep "pull request" | awk '{print $1}' | xargs git show --format='%b' | grep -v Approved | grep -v "^$" | grep -E "^[[:space:]]*\[.*\]"#
+            ).output.split('\n').map(&:strip)
+          end
+        },
+        default_proc: ->(hash, _) { raise InvalidChangelogSource, "Invalid CHANGELOG Source, avaliable options: '#{hash.keys.join(',')}'" }
+      )
+
+      def call(new_version:, confirmation: true, filename: 'CHANGELOG.md', with: :merged_pull_requests_with_bracketed_labels)
+        verify_file_presence!(filename)
+
+        stdout.puts separator
+        changelog_changes = format_changes(new_version, version_changes(with))
+
+        exit if confirmation && !cli_helpers.confirm("Create new Realease?\n" \
+                                                     "#{separator}\n" \
+                                                     "#{changelog_changes}" \
+                                                     "#{separator}\n")
+        update_file(filename, changelog_changes)
+      end
+
+      private
+
+      def verify_file_presence!(filename)
+        raise Verto::ExitError, "changelog file '#{filename}' doesnt exist" unless Verto.project_path.join(filename).exist?
+      end
+
+      def version_changes(with)
+        SOURCES[with].call(executor)
+      end
+
+      def update_file(filename, changelog_changes)
+        DSL::File.new(filename).prepend(changelog_changes)
+      end
+
+      def format_changes(new_version, version_changes)
+        Mustache.render(changelog_format, { new_version: new_version, version_changes: version_changes }) + "\n"
+      end
+
+      def separator
+        '---------------------------'
+      end
+    end
+  end
+end

--- a/lib/verto/utils/cli_helpers.rb
+++ b/lib/verto/utils/cli_helpers.rb
@@ -1,0 +1,13 @@
+module CliHelpers
+  class << self
+    def confirm(text)
+      shell_basic.yes?("#{text} (y/n)")
+    end
+
+    private
+
+    def shell_basic
+      @shell_basic ||= Thor::Shell::Basic.new
+    end
+  end
+end

--- a/lib/verto/utils/strict_hash.rb
+++ b/lib/verto/utils/strict_hash.rb
@@ -1,0 +1,7 @@
+class StrictHash < Hash
+  def initialize(hash, default_proc: nil)
+    super()
+    self.default_proc = default_proc if default_proc
+    merge!(hash)
+  end
+end

--- a/lib/verto/utils/templates/Vertofile
+++ b/lib/verto/utils/templates/Vertofile
@@ -6,43 +6,41 @@ config {
  # project.path = "#{project_path}" # Configures a custom project path
  # git.pull_before_tag_creation = true # Pull Changes before tag creation
  # git.push_after_tag_creation = true # Push changes after tag creation
+
+ ## CHANGELOG FORMAT
+ ## Verto uses Mustache template rendering to render changelog updates, the default value is:
+ ##
+ ##   ## {{new_version}} - #{Time.now.strftime('%d/%m/%Y')}
+ ##       {{#version_changes}}
+ ##       * {{.}}
+ ##       {{/version_changes}}
+ ##
+ ## A custom format can be specified, eg:
+ # changelog.format =  <<~CHANGELOG
+ #                       ## {{new_version}}
+ #                        {{#version_changes}}
+ #                        * {{.}}
+ #                        {{/version_changes}}
+ #                      CHANGELOG}
 }
 
 context(branch('master')) {
   before_command_tag_up {
-    git!('pull origin master')
     command_options.add(filter: 'release_only')
   }
 
   before_tag_creation{
-    version_changes = ""
-    # Uncomment to get Merged PRs Titles as changes to add in CHANGELOG.
-    # version_changes = sh(
-    #  %q#git log --oneline --decorate  | grep -B 100 -m 1 "tag:" | grep "pull request" | awk '{print $1}' | xargs git show --format='%b' | grep -v Approved | grep -v "^$" | grep -E "^[[:space:]]*\[.*\]" | sed 's/^[[:space:]]*\(.*\)/ * \1/'#, output: false
-    # ).output
-
-    puts "---------------------------"
-    version_changes = "## #{new_version} - #{Time.now.strftime('%d/%m/%Y')}\n#{version_changes}\n"
-    exit unless confirm("Create new Realease?\n" \
-      "---------------------------\n" \
-      "#{version_changes}" \
-      "---------------------------\n"
-    )
-
-    # CHANGELOG
-    file('CHANGELOG.md').prepend(version_changes)
-    git('add CHANGELOG.md')
+    # Uncomment to update CHANGELOG file
+    # update_changelog(with: :merged_pull_requests_with_bracketed_labels,
+    #                  confirmation: true,
+    #                  filename: 'CHANGELOG.md')
+    # git('add CHANGELOG.md')
 
     # Uncomment to update the version in other files, like package.json
     # file('package.json').replace(/"(\d+)\.(\d+)\.(\d+)(-?.*)"/, %Q{"#{new_version}"})
     # git('add package.json')
 
     git('commit -m "Updates CHANGELOG"')
-  }
-
-  after_command_tag_up {
-    git('push --tags')
-    git('push origin master')
   }
 }
 
@@ -60,8 +58,7 @@ context(branch('master')) {
 #  }
 
 #  after_command_tag_up {
-#    git('push --tags')
-#    git('push origin staging')
+#    sh('some command')
 #  }
 #}
 

--- a/spec/helpers/test_repo.rb
+++ b/spec/helpers/test_repo.rb
@@ -1,6 +1,8 @@
 require 'fileutils'
 
 class TestRepo
+  attr_accessor :path
+
   def initialize(path=Verto.root_path.join('tmp/test_repo'))
     FileUtils.mkdir_p(path)
     @path = path
@@ -27,7 +29,7 @@ class TestRepo
   end
 
   def commit!(message)
-    run "git commit -m #{message} --allow-empty"
+    run "git commit -m '#{message}' --allow-empty"
   end
 
   def checkout(branch)

--- a/spec/verto/dsl/syntax_spec.rb
+++ b/spec/verto/dsl/syntax_spec.rb
@@ -1,2 +1,40 @@
 RSpec.describe Verto::DSL::Syntax do
+   let(:class_with_syntax) { Class.new { include Verto::DSL:: Syntax } }
+   let(:instance) { class_with_syntax.new }
+
+  describe '#update_changelog' do
+    subject(:update_changelog) { instance.update_changelog(with: source_option, filename: changelog_file) }
+
+    let(:update_changelog_instance) { Verto::DSL::UpdateChangelog.new }
+    let(:source_option) { :merged_pull_requests_with_bracketed_labels }
+    let(:changelog_file) { 'CHANGELOG.md' }
+    let(:user_confirm) { true }
+    let(:new_version) { '1.1.1' }
+
+    before do
+      allow(instance).to receive(:new_version).and_return(new_version)
+      allow(CliHelpers).to receive(:confirm).and_return(user_confirm)
+      allow(Verto::DSL::UpdateChangelog).to receive(:new).and_return(update_changelog_instance)
+      Verto.current_moment = :before_tag_creation
+    end
+
+    it 'calls UpdateChangelog' do
+      allow(update_changelog_instance).to receive(:call)
+
+      update_changelog
+
+      expect(update_changelog_instance).to have_received(:call).with(with: source_option,
+                                                                     filename: changelog_file,
+                                                                     new_version: new_version,
+                                                                     confirmation: true)
+    end
+
+    context 'when is called without the scope of before_tag_creation or after_tag_up' do
+      before { Verto.current_moment = nil }
+
+      it 'raises a error' do
+        expect { update_changelog }.to raise_error(Verto::ExitError, "update_changelog is only supported in before_tag_creation or after_command_tag_up")
+      end
+    end
+  end
 end

--- a/spec/verto/dsl/update_changelog_spec.rb
+++ b/spec/verto/dsl/update_changelog_spec.rb
@@ -1,0 +1,182 @@
+RSpec.describe Verto::DSL::UpdateChangelog do
+  before do
+    Verto.config.project.path = repo.path.to_s
+    allow(Verto).to receive(:stdout).and_return(stdout)
+    allow(Verto).to receive(:stderr).and_return(stderr)
+  end
+
+  let(:repo) { TestRepo.new }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:instance) { described_class.new }
+
+  describe '#call' do
+    subject(:update_changelog) { instance.call(with: source_option, filename: changelog_file, new_version: new_version) }
+
+    before do
+      repo.init!
+      allow(CliHelpers).to receive(:confirm).and_return(user_confirm)
+      allow(instance).to receive(:new_version).and_return(new_version)
+    end
+
+    after do
+      repo.clear!
+    end
+
+    let(:source_option) { :merged_pull_requests_with_bracketed_labels }
+    let(:changelog_file) { 'CHANGELOG.md' }
+    let(:user_confirm) { true }
+    let(:new_version) { '1.1.1' }
+    let(:current_time) { Time.now.strftime('%d/%m/%Y') }
+
+    RSpec.shared_examples 'updates CHANGELOG.md' do |expected_changelog_content:|
+      it 'asks for confirmation' do
+        update_changelog
+
+        expect(CliHelpers).to have_received(:confirm).once
+      end
+
+      it 'updates CHANGELOG.md' do
+        expect { update_changelog }
+          .to change { File.read(repo.path.join(changelog_file)) }
+          .to(expected_changelog_content)
+      end
+    end
+
+    context 'with merged pull requests from bitbucket after last tag' do
+      before do
+        repo.tag!('1.1.0')
+        repo.commit!(
+          <<~COMMIT
+          Merged in fix/simple_fix (pull request #42)
+
+          [FIX] A simple fix
+
+          Approved-by: User One <user1@test.com>
+          Approved-by: User Two <user2@test.com>
+          COMMIT
+        )
+        repo.run("touch #{changelog_file}")
+      end
+
+      include_examples 'updates CHANGELOG.md',
+        expected_changelog_content:
+        <<~CHANGELOG
+                          ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+                           * [FIX] A simple fix
+
+      CHANGELOG
+
+      context 'with a changelog with a previous content' do
+        before do
+          repo.run("echo '## 1.1.0 - 12/10/2020' > #{changelog_file}")
+        end
+
+        include_examples 'updates CHANGELOG.md',
+          expected_changelog_content:
+          <<~CHANGELOG
+                            ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+                             * [FIX] A simple fix
+
+                            ## 1.1.0 - 12/10/2020
+        CHANGELOG
+      end
+    end
+
+    context 'with merged pull requests from github after last tag' do
+      before do
+        repo.tag!('1.1.0')
+        repo.commit!(
+          <<~COMMIT
+            Merge pull request #18 from catks/feature/custom_default_identifier
+
+            [FEATURE] Custom Defaults
+
+          COMMIT
+        )
+        repo.run("touch #{changelog_file}")
+      end
+
+      include_examples 'updates CHANGELOG.md',
+        expected_changelog_content:
+        <<~CHANGELOG
+                          ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+                           * [FEATURE] Custom Defaults
+
+      CHANGELOG
+
+      context 'with a changelog with a previous content' do
+        before do
+          repo.run("echo '## 1.1.0 - 12/10/2020' > #{changelog_file}")
+        end
+
+        include_examples 'updates CHANGELOG.md',
+          expected_changelog_content:
+          <<~CHANGELOG
+                            ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+                             * [FEATURE] Custom Defaults
+
+                            ## 1.1.0 - 12/10/2020
+        CHANGELOG
+      end
+    end
+
+    context 'without merged pull requests' do
+      before do
+        repo.run("touch #{changelog_file}")
+      end
+
+      include_examples 'updates CHANGELOG.md',
+        expected_changelog_content:
+        <<~CHANGELOG
+                            ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+
+      CHANGELOG
+    end
+
+    context 'without a changelog file' do
+      it 'raises a error' do
+        expect { update_changelog }.to raise_error(Verto::ExitError, "changelog file '#{changelog_file}' doesnt exist")
+      end
+    end
+
+    context 'with a custom changelog file' do
+      let(:changelog_file) { 'changelog.md' }
+
+      before do
+        repo.run("touch #{changelog_file}")
+        repo.tag!('1.1.0')
+        repo.commit!(
+          <<~COMMIT
+            Merge pull request #18 from catks/feature/custom_default_identifier
+
+            [FEATURE] Custom Defaults
+
+          COMMIT
+        )
+      end
+
+      include_examples 'updates CHANGELOG.md',
+        expected_changelog_content:
+        <<~CHANGELOG
+                          ## 1.1.1 - #{Time.now.strftime('%d/%m/%Y')}
+                           * [FEATURE] Custom Defaults
+
+      CHANGELOG
+    end
+
+    context 'with a invalid source option' do
+      let(:source_option) { :not_a_option }
+
+      before do
+        repo.run("touch #{changelog_file}")
+      end
+
+      it 'raises a error' do
+        expect { update_changelog }
+          .to raise_error(Verto::DSL::UpdateChangelog::InvalidChangelogSource,
+                          "Invalid CHANGELOG Source, avaliable options: 'merged_pull_requests_with_bracketed_labels'")
+      end
+    end
+  end
+end

--- a/verto.gemspec
+++ b/verto.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency             "dry-container", "~> 0.7"
   spec.add_dependency             "dry-auto_inject", "~> 0.7"
   spec.add_dependency             "vseries", "~> 0.2"
+  spec.add_dependency             "mustache", "~> 1.1.1"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
  Adds option to auto `update_changelog` using sources and custom formats, eg:

  ```
   config {
    changelog.format =  <<~CHANGELOG
                          ## {{new_version}}
                           {{#version_changes}}
                           * {{.}}
                           {{/version_changes}}
                         CHANGELOG
   }

   context(branch('master')) {
      before_tag_creation{
        update_changelog(with: :merged_pull_requests_with_bracketed_labels,
                         confirmation: true,
                         filename: 'CHANGELOG.md')

        git('add CHANGELOG.md')
        git('commit -m "Updates CHANGELOG"')
    }
  }
  ...
  ```