### PR TITLE
  [FEATURE] Adds fetch_before_tag_creation built-in hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ config {
  # version.prefix = 'v' # Adds a version_prefix
  # pre_release.default_identifier = 'alpha' } # Defaults to 'rc'
  git.pull_before_tag_creation = true # Pull Changes before tag creation
+ git.fetch_before_tag_creation = true # Fetch Branches and Tags before tag creation
  git.push_after_tag_creation = true # Push changes after tag creation
 
  ## CHANGELOG FORMAT

--- a/lib/verto.rb
+++ b/lib/verto.rb
@@ -38,6 +38,7 @@ module Verto
   setting :git do
     setting :pull_before_tag_creation, false
     setting :push_after_tag_creation, false
+    setting :fetch_before_tag_creation, false
   end
 
   setting :changelog do

--- a/lib/verto/dsl/built_in_hooks.rb
+++ b/lib/verto/dsl/built_in_hooks.rb
@@ -7,6 +7,10 @@ module Verto
         git!("pull origin #{current_branch}")
       end
 
+      GitFetch = DSL::Hook.new(moment: :before) do
+        git!('fetch')
+      end
+
       GitPushTags = DSL::Hook.new(moment: :after) do
         git!('push --tags')
       end

--- a/lib/verto/utils/templates/Vertofile
+++ b/lib/verto/utils/templates/Vertofile
@@ -5,6 +5,7 @@ config {
  # pre_release.initial_number = 0 # Configures pre_release initial number, defaults to 1
  # project.path = "#{project_path}" # Configures a custom project path
  # git.pull_before_tag_creation = true # Pull Changes before tag creation
+ # git.fetch_before_tag_creation = true # Fetch Branches and Tags before tag creation
  # git.push_after_tag_creation = true # Push changes after tag creation
 
  ## CHANGELOG FORMAT

--- a/spec/verto/dsl/built_in_hooks_spec.rb
+++ b/spec/verto/dsl/built_in_hooks_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Verto::DSL::BuiltInHooks do
     end
   end
 
+  describe described_class::GitFetch do
+    subject(:call) { described_class.call }
+
+    it 'pull current branch changes' do
+      allow(interpreter).to receive(:git!)
+
+      call
+
+      expect(interpreter).to have_received(:git!).with('fetch').once
+    end
+  end
+
   describe described_class::GitPushTags do
     subject(:call) { described_class.call }
 

--- a/spec/verto/lib/commands/main_command_spec.rb
+++ b/spec/verto/lib/commands/main_command_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Verto::MainCommand do
               <<~VERTOFILE
                 config {
                   git.pull_before_tag_creation = true
+                  git.fetch_before_tag_creation = true
                   git.push_after_tag_creation = true
                 }
               VERTOFILE
@@ -296,6 +297,7 @@ RSpec.describe Verto::MainCommand do
             before do
               allow(Verto::DSL::BuiltInHooks::GitPullCurrentBranch).to receive(:call)
               allow(Verto::DSL::BuiltInHooks::GitPushCurrentBranch).to receive(:call)
+              allow(Verto::DSL::BuiltInHooks::GitFetch).to receive(:call)
             end
 
             it 'create a tag' do
@@ -308,9 +310,17 @@ RSpec.describe Verto::MainCommand do
             it 'pulls changes before creating a tag' do
               up
 
-              expect(Verto.config.hooks.select { |h| h.moment == :before }.first)
+              expect(Verto.config.hooks.select { |h| h.moment == :before }.last)
                 .to eq(Verto::DSL::BuiltInHooks::GitPullCurrentBranch)
               expect(Verto::DSL::BuiltInHooks::GitPullCurrentBranch).to have_received(:call)
+            end
+
+            it 'fetchs changes before creating a tag' do
+              up
+
+              expect(Verto.config.hooks.select { |h| h.moment == :before }.first)
+                .to eq(Verto::DSL::BuiltInHooks::GitFetch)
+              expect(Verto::DSL::BuiltInHooks::GitFetch).to have_received(:call)
             end
 
             it 'push changes after creating a tag' do


### PR DESCRIPTION
  Adds new config `git.fetch_before_tag_creation` to run git fetch
  before the tag creation